### PR TITLE
Add jest test cases for login and signup

### DIFF
--- a/src/pages/login/Login.test.js
+++ b/src/pages/login/Login.test.js
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { MemoryRouter } from 'react-router-dom';  // for Link navigation
+import Login from './Login';
+import useLogin from '../../hooks/useLogin';
+
+// Mocking the useLogin hook
+jest.mock('../../hooks/useLogin');
+
+describe('Login Component', () => {
+  beforeEach(() => {
+    useLogin.mockReturnValue({
+      email: '',
+      setEmail: jest.fn(),
+      password: '',
+      setPassword: jest.fn(),
+      callLogin: jest.fn(),
+    });
+  });
+
+  test('renders the Login form', () => {
+    render(
+      <MemoryRouter>
+        <Login />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/Login/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/Enter your email/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/Enter your password/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Login/i })).toBeInTheDocument();
+    expect(screen.getByText(/Don't have an account\?/i)).toBeInTheDocument();
+  });
+
+  test('shows validation errors when form is submitted with empty fields', () => {
+    render(
+      <MemoryRouter>
+        <Login />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Login/i }));
+
+    expect(screen.getByText(/Email is required/i)).toBeInTheDocument();
+    expect(screen.getByText(/Password is required/i)).toBeInTheDocument();
+  });
+
+  test('shows email validation error when an invalid email is entered', () => {
+    render(
+      <MemoryRouter>
+        <Login />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/Enter your email/i), {
+      target: { value: 'invalidemail' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Login/i }));
+
+    expect(screen.getByText(/Please enter a valid email address/i)).toBeInTheDocument();
+  });
+
+  test('submits the form when valid input is provided', () => {
+    const mockCallLogin = jest.fn();
+
+    useLogin.mockReturnValue({
+      email: 'test@example.com',
+      setEmail: jest.fn(),
+      password: 'password123',
+      setPassword: jest.fn(),
+      callLogin: mockCallLogin,
+    });
+
+    render(
+      <MemoryRouter>
+        <Login />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Login/i }));
+
+    expect(mockCallLogin).toHaveBeenCalledWith('test@example.com', 'password123');
+  });
+
+  test('renders a link to the signup page', () => {
+    render(
+      <MemoryRouter>
+        <Login />
+      </MemoryRouter>
+    );
+
+    const signupLink = screen.getByText(/Signup/i);
+    expect(signupLink).toBeInTheDocument();
+    expect(signupLink.closest('a')).toHaveAttribute('href', '/signup');
+  });
+});

--- a/src/pages/signup/Signup.test.js
+++ b/src/pages/signup/Signup.test.js
@@ -1,0 +1,125 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { MemoryRouter } from 'react-router-dom';
+import Signup from './Signup';
+import useSignup from '../../hooks/useSignup';
+
+// Mock the useSignup hook
+jest.mock('../../hooks/useSignup');
+
+describe('Signup Component', () => {
+  beforeEach(() => {
+    useSignup.mockReturnValue({
+      name: '',
+      setName: jest.fn(),
+      email: '',
+      setEmail: jest.fn(),
+      password: '',
+      setPassword: jest.fn(),
+      callSignup: jest.fn(),
+    });
+  });
+
+  test('renders the signup form', () => {
+    render(
+      <MemoryRouter>
+        <Signup />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/Sign Up/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/Enter your username/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/Enter your email/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/Enter your password/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Sign Up/i })).toBeInTheDocument();
+  });
+
+  test('shows validation errors when submitting empty form', () => {
+    render(
+      <MemoryRouter>
+        <Signup />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Sign Up/i }));
+
+    expect(screen.getByText(/Username is required/i)).toBeInTheDocument();
+    expect(screen.getByText(/Email is required/i)).toBeInTheDocument();
+    expect(screen.getByText(/Password is required/i)).toBeInTheDocument();
+  });
+
+  test('shows email validation error when invalid email is entered', () => {
+    render(
+      <MemoryRouter>
+        <Signup />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/Enter your email/i), {
+      target: { value: 'invalidemail' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Sign Up/i }));
+
+    expect(screen.getByText(/Please enter a valid email address/i)).toBeInTheDocument();
+  });
+
+  test('displays password strength feedback based on input', () => {
+    render(
+      <MemoryRouter>
+        <Signup />
+      </MemoryRouter>
+    );
+
+    const passwordInput = screen.getByPlaceholderText(/Enter your password/i);
+
+    // Weak password (only lowercase)
+    fireEvent.change(passwordInput, { target: { value: 'abc' } });
+    expect(screen.getByText(/At least 8 characters/i)).toHaveClass('text-gray-500');
+    expect(screen.getByText(/At least one uppercase letter/i)).toHaveClass('text-gray-500');
+
+    // Stronger password
+    fireEvent.change(passwordInput, { target: { value: 'Abc12345!' } });
+    expect(screen.getByText(/At least 8 characters/i)).toHaveClass('text-green-500');
+    expect(screen.getByText(/At least one uppercase letter/i)).toHaveClass('text-green-500');
+    expect(screen.getByText(/At least one number/i)).toHaveClass('text-green-500');
+    expect(screen.getByText(/At least one special character/i)).toHaveClass('text-green-500');
+  });
+
+  test('calls the signup function with valid input', () => {
+    const mockCallSignup = jest.fn();
+
+    useSignup.mockReturnValue({
+      name: 'TestUser',
+      setName: jest.fn(),
+      email: 'test@example.com',
+      setEmail: jest.fn(),
+      password: 'Password123!',
+      setPassword: jest.fn(),
+      callSignup: mockCallSignup,
+    });
+
+    render(
+      <MemoryRouter>
+        <Signup />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Sign Up/i }));
+
+    expect(mockCallSignup).toHaveBeenCalledWith('TestUser', 'test@example.com', 'Password123!');
+  });
+
+  test('renders link to login page', () => {
+    render(
+      <MemoryRouter>
+        <Signup />
+      </MemoryRouter>
+    );
+
+    const loginLink = screen.getByText(/Login/i);
+    expect(loginLink).toBeInTheDocument();
+    expect(loginLink).toHaveAttribute('href', '/login');
+  });
+});


### PR DESCRIPTION
Fixes #9 

This PR adds two Jest test case files for the `Login` and `Signup` components. 

The test cases ensures:
1. Both forms render correctly, validate user input, and handle submission events. 
2. The form fields display validation errors for incorrect inputs and simulate form submission. 
3. The `Signup` component tests password strength indicators and field validation.
4. Proper routing to the login page is validated.

Please review and merge this PR.